### PR TITLE
Swift PM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ DerivedData
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
@@ -34,3 +34,5 @@ DerivedData
 
 Carthage/Build
 
+# SwiftPM
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "QuickLayout",
+  platforms: [
+    .iOS(.v9),
+    .tvOS(.v9),
+    .macOS(.v10_10)
+  ],
+  products: [
+    .library(name: "QuickLayout", targets: ["QuickLayout"])
+  ],
+  targets: [
+    .target(
+      name: "QuickLayout",
+      dependencies: [],
+      path: "QuickLayout"
+    )
+  ],
+  swiftLanguageVersions: [
+    .v5
+  ]
+)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can harness the power of QuickLayout to align your interface programmaticall
 * [Installation](#installation)
   * [CocoaPods](#cocoapods)
   * [Carthage](#carthage)
+  * [Swift Package Manager](#swift-package-manager)
   * [Manually](#manually)
 * [Usage](#usage)
   * [Constant edges](#constant-edges)
@@ -115,6 +116,12 @@ To integrate QuickLayout into your Xcode project using Carthage, specify the fol
 ```ogdl
 github "huri000/QuickLayout" == 3.0.0
 ```
+### Swift Package Manager
+
+The [Swift Package Manager](https://swift.org/package-manager/) is a tool for managing the distribution of Swift code. It’s integrated with the Swift build system to automate the process of downloading, compiling, and linking dependencies.
+
+Using Xcode 11.0+ go to your project file and enter the project URL of this repository:
+`https://github.com/huri000/QuickLayout`
 
 #### Manually
 


### PR DESCRIPTION
### Goals 🥅
- Add support for Swift Package Manager

### Implementation Details ✏️
- Added Package.swift
- Details added to README on how to include in your project.
  - This can be added without Xcode 11, but that is the easiest implementation.

### Testing Details 🔍
- I checked that everything compiled when a package was included into a project