### PR TITLE
Set Xcode build system to `new`

### DIFF
--- a/Example/QuickLayout.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/QuickLayout.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
### Issue Link 🔗
https://github.com/huri000/QuickLayout/issues/38

### Goals 🥅
Re-enables Carthage build using Xcode 13

### How to Test
1. Create empty xcode project
2. Create Cartfile with content `github "Blackjacx/QuickLayout" "master"`
3. Run `carthage build --no-skip-current --use-xcframeworks`

Doing the same when the Cartfile instead contains `github "Blackjacx/QuickLayout"` (latest tag) fails

### Important

When this has been changed please also update the reference of SwiftEntryKit to the new release so we can actually use it. Thanks a lot :)